### PR TITLE
QOL changes and string comparison helper

### DIFF
--- a/pycheevos/core/condition.py
+++ b/pycheevos/core/condition.py
@@ -55,6 +55,16 @@ class ConditionList(list):
             self[-1] = self[-1].with_hits(hits)
         return self
 
+    def render(self) -> str:
+        return "_".join(map(str, self))
+    
+    def __str__(self):
+        return self.render()
+    
+    def __repr__(self):
+        return self.render()
+
+
 class Condition:
     def __init__(
             self,

--- a/pycheevos/core/helpers.py
+++ b/pycheevos/core/helpers.py
@@ -74,9 +74,11 @@ def string_equals(
     endianness: Literal["little", "big"] = "big"
 ) -> ConditionList:
     conditions = ConditionList()
-    b = string.encode(encoding)
     if length == 0:
+        b = string.encode(encoding)
         length = len(b)
+    else:
+        b = string.encode(encoding)[:length]
     for i in range(0, length, 4):
         chunk = b[i: i + 4]
         size = {

--- a/pycheevos/core/helpers.py
+++ b/pycheevos/core/helpers.py
@@ -1,5 +1,8 @@
+from typing import Callable, Literal, Union
+
 from pycheevos.core.value import MemoryValue, RecallValue, ConstantValue
 from pycheevos.core.constants import MemorySize, Flag
+from pycheevos.core.condition import Condition, ConditionList
 
 def byte(address: int) -> MemoryValue: return MemoryValue(address, MemorySize.BIT8)
 def word(address: int) -> MemoryValue: return MemoryValue(address, MemorySize.BIT16)
@@ -40,6 +43,11 @@ def recall() -> RecallValue: return RecallValue()
 
 def value(value: int) -> ConstantValue: return ConstantValue(value)
 
+def group(*args) -> ConditionList: return ConditionList(args)
+
+def always_true() -> Condition: return value(1) == value(1)
+def always_false() -> Condition: return value(0) == value(1)
+
 # --- New Flag Helper Functions ---
 def pause_if(condition):         return condition.with_flag(Flag.PAUSE_IF)
 def reset_if(condition):         return condition.with_flag(Flag.RESET_IF)
@@ -56,3 +64,39 @@ def remember(condition):         return condition.with_flag(Flag.REMEMBER)
 def and_next(condition):         return condition.with_flag(Flag.AND_NEXT)
 def or_next(condition):          return condition.with_flag(Flag.OR_NEXT)
 def measured_percent(condition): return condition.with_flag(Flag.MEASURED_PERCENT)
+
+def string_equals(
+    address: int,
+    string: str,
+    length: int = 0,
+    transform: Union[Callable, None] = None,
+    encoding: str = "ascii",
+    endianness: Literal["little", "big"] = "big"
+) -> ConditionList:
+    conditions = ConditionList()
+    b = string.encode(encoding)
+    if length == 0:
+        length = len(b)
+    for i in range(0, length, 4):
+        chunk = b[i: i + 4]
+        size = {
+            "little": {
+                1: byte,
+                2: word,
+                3: tbyte,
+                4: dword,
+            },
+            "big": {
+                1: byte,
+                2: word_be,
+                3: tbyte_be,
+                4: dword_be,
+            }
+        }[endianness][len(chunk)]
+        lvalue = size(address + i)
+        if transform is not None:
+            lvalue = transform(lvalue)
+        rvalue = value(int.from_bytes(chunk, byteorder=endianness))
+        conditions.append(and_next(lvalue == rvalue))
+    conditions = conditions.with_flag(Flag.NONE)
+    return conditions

--- a/pycheevos/core/readme.md
+++ b/pycheevos/core/readme.md
@@ -6,25 +6,28 @@ While [`models`](https://github.com/CarlosNatanael/PyCheevos/tree/main/models) (
 
 ### Table of Contents
 
-1. [Memory Helpers](#1-memory-helpers)
-    - [Standard Sizes](#standard-sizes)
-    - [Bits & Nibbles](#bits--nibbles)
-    - [Floating Point](#floating-point)
-2. [Constants & Safety (`value`)](#2-constants--safety-value)
-3. [Enums & Constants](#3-enums--constants)
-    - [Achievement Types](#achievement-types)
-    - [Leaderboard Formats](#leaderboard-formats)
-4. [Value Modifiers](#4-value-modifiers)
-5. [Arithmetic & Pointers](#5-arithmetic--pointers)
-    - [Basic Math](#basic-math)
-    - [Pointer Chains](#pointer-chains-)
-6. [Bitwise Operations](#6-bitwise-operations-memory)
-7. [Conditions, Flags & Logic](#7-conditions-flags--logic)
-    - [Logic Helpers (New Syntax)](#logic-helpers-new-syntax)
-    - [Hit Counts](#hit-counts-with_hits)
-    - [Applying Flags (Manual)](#applying-flags-manual)
-    - [Logical Operators (Chain)](#logical-operators-chain)
-8. [Remember & Recall](#8-remember--recall)
+- [@pycheevos/core](#pycheevoscore)
+    - [Table of Contents](#table-of-contents)
+    - [1. **Memory Helpers**](#1-memory-helpers)
+      - [**Standard Sizes**](#standard-sizes)
+      - [**Bits \& Nibbles**](#bits--nibbles)
+      - [**Floating Point**](#floating-point)
+    - [2. **Constants \& Safety (`value`)**](#2-constants--safety-value)
+    - [3. **Enums \& Constants**](#3-enums--constants)
+      - [**Achievement Types**](#achievement-types)
+      - [**Leaderboard Formats**](#leaderboard-formats)
+    - [4. **Value Modifiers**](#4-value-modifiers)
+    - [5. Arithmetic \& Pointers](#5-arithmetic--pointers)
+      - [**Basic Math**](#basic-math)
+      - [**Pointer Chains** (`>>`)](#pointer-chains-)
+    - [6. **Bitwise Operations (Memory)**](#6-bitwise-operations-memory)
+    - [7. **Conditions, Flags \& Logic**](#7-conditions-flags--logic)
+      - [**Logic Helpers (New Syntax)**](#logic-helpers-new-syntax)
+      - [**Hit Counts (`.with_hits`)**](#hit-counts-with_hits)
+      - [**Applying Flags (Manual)**](#applying-flags-manual)
+      - [**Logical Operators (Chain)**](#logical-operators-chain)
+    - [8. **Remember \& Recall**](#8-remember--recall)
+    - [9. **Strings**](#9-strings)
 
 ---
 
@@ -230,3 +233,27 @@ logic = [
     byte(0xAmmo) > recall()
 ]
 ```
+
+### 9. **Strings**
+
+Use the helper method `string_equals` to generate string comparison conditions.
+
+**Parameters:**
+* `address`: (Required) Memory address to compare.
+* `string`: (Required) String value to compare.
+* `length`: Fixed string length in bytes, default to the full encoded length of `string`.
+* `transform`: Any transform method or lambda that will be applied to the left value of each condition as such: `transform(lvalue)`.
+* `endianness`: `"big"` or `"little"`, default to `"big"`.
+* `encoding`: Any python-supported encoding such as `"utf-8"`, `"utf-16"`, `"shift-jis"`... default to `"ascii"`.
+
+```python
+from pycheevos.core.helpers import string_equals, delta
+
+address = 0x1000
+# Minimal Example
+logic = string_equals(address, "Hello World")
+# Full Example
+logic = string_equals(address, "Hello World", 4, transform=delta, endianness="little", encoding="utf-8")
+```
+
+More examples at [`strings.md`](/pycheevos/examples/strings.md)

--- a/pycheevos/core/value.py
+++ b/pycheevos/core/value.py
@@ -202,12 +202,12 @@ class RecallValue(MemoryValue):
     def render(self) -> str:
         return "{recall}"
     
-    def __rshift__(self, other):
+    def __rshift__(self, other): # type: ignore
         from .condition import Condition, ConditionList
         # other is already a Condition or ConditionList — prepend recall as ADD_ADDRESS
         addr_condition = Condition(self, flag=Flag.ADD_ADDRESS)
         if isinstance(other, ConditionList):
-            return ConditionList([addr_condition] + other.conditions)
+            return ConditionList([addr_condition] + other)
         elif isinstance(other, Condition):
             return ConditionList([addr_condition, other])
         else:

--- a/pycheevos/examples/strings.md
+++ b/pycheevos/examples/strings.md
@@ -45,7 +45,7 @@
 |   5 | AndNext | Mem     | 32-bit BE | 0x1010   | =    | Value   |         | 0x6f007200 |        |
 |   6 |         | Mem     | 32-bit BE | 0x1014   | =    | Value   |         | 0x6c006400 |        |
 
-### Example 6: Japanese LE SHIFT-JIS
+### Example 7: Japanese LE SHIFT-JIS
 `string_equals(0x1000, "こんにちは", encoding="shift-jis", endianness="little")`
 |   # | Flag    | LType   | LSize   | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
 |----:|:--------|:--------|:--------|:---------|:-----|:--------|:--------|:-----------|:-------|

--- a/pycheevos/examples/strings.md
+++ b/pycheevos/examples/strings.md
@@ -1,0 +1,55 @@
+### Example 1: Hi
+`string_equals(0x1000, "Hi")`
+|   # | Flag   | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue   | Hits   |
+|----:|:-------|:--------|:----------|:---------|:-----|:--------|:--------|:---------|:-------|
+|   1 |        | Mem     | 16-bit BE | 0x1000   | =    | Value   |         | 0x4869   |        |
+
+### Example 2: Hello World
+`string_equals(0x1000, "Hello World")`
+|   # | Flag    | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:--------|:--------|:----------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 | AndNext | Mem     | 32-bit BE | 0x1000   | =    | Value   |         | 0x48656c6c |        |
+|   2 | AndNext | Mem     | 32-bit BE | 0x1004   | =    | Value   |         | 0x6f20576f |        |
+|   3 |         | Mem     | 24-bit BE | 0x1008   | =    | Value   |         | 0x726c64   |        |
+
+### Example 3: Fixed length
+`string_equals(0x1000, "Hello World", 3)`
+|   # | Flag   | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:-------|:--------|:----------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 |        | Mem     | 32-bit BE | 0x1000   | =    | Value   |         | 0x48656c6c |        |
+
+### Example 4: Transform method
+`string_equals(0x1000, "Hello World", transform=delta)`
+|   # | Flag    | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:--------|:--------|:----------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 | AndNext | Delta   | 32-bit BE | 0x1000   | =    | Value   |         | 0x48656c6c |        |
+|   2 | AndNext | Delta   | 32-bit BE | 0x1004   | =    | Value   |         | 0x6f20576f |        |
+|   3 |         | Delta   | 24-bit BE | 0x1008   | =    | Value   |         | 0x726c64   |        |
+
+### Example 5: Little endian
+`string_equals(0x1000, "Hello World", endianness="little")`
+|   # | Flag    | LType   | LSize   | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:--------|:--------|:--------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 | AndNext | Mem     | 32-bit  | 0x1000   | =    | Value   |         | 0x6c6c6548 |        |
+|   2 | AndNext | Mem     | 32-bit  | 0x1004   | =    | Value   |         | 0x6f57206f |        |
+|   3 |         | Mem     | 24-bit  | 0x1008   | =    | Value   |         | 0x646c72   |        |
+
+### Example 6: UTF-16 encoding
+`string_equals(0x1000, "Hello World", encoding="utf-16")`
+|   # | Flag    | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:--------|:--------|:----------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 | AndNext | Mem     | 32-bit BE | 0x1000   | =    | Value   |         | 0xfffe4800 |        |
+|   2 | AndNext | Mem     | 32-bit BE | 0x1004   | =    | Value   |         | 0x65006c00 |        |
+|   3 | AndNext | Mem     | 32-bit BE | 0x1008   | =    | Value   |         | 0x6c006f00 |        |
+|   4 | AndNext | Mem     | 32-bit BE | 0x100c   | =    | Value   |         | 0x20005700 |        |
+|   5 | AndNext | Mem     | 32-bit BE | 0x1010   | =    | Value   |         | 0x6f007200 |        |
+|   6 |         | Mem     | 32-bit BE | 0x1014   | =    | Value   |         | 0x6c006400 |        |
+
+### Example 6: Japanese LE SHIFT-JIS
+`string_equals(0x1000, "こんにちは", encoding="shift-jis", endianness="little")`
+|   # | Flag    | LType   | LSize   | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
+|----:|:--------|:--------|:--------|:---------|:-----|:--------|:--------|:-----------|:-------|
+|   1 | AndNext | Mem     | 32-bit  | 0x1000   | =    | Value   |         | 0xf182b182 |        |
+|   2 | AndNext | Mem     | 32-bit  | 0x1004   | =    | Value   |         | 0xbf82c982 |        |
+|   3 |         | Mem     | 16-bit  | 0x1008   | =    | Value   |         | 0xcd82     |        |
+

--- a/pycheevos/examples/strings.md
+++ b/pycheevos/examples/strings.md
@@ -14,9 +14,9 @@
 
 ### Example 3: Fixed length
 `string_equals(0x1000, "Hello World", 3)`
-|   # | Flag   | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue     | Hits   |
-|----:|:-------|:--------|:----------|:---------|:-----|:--------|:--------|:-----------|:-------|
-|   1 |        | Mem     | 32-bit BE | 0x1000   | =    | Value   |         | 0x48656c6c |        |
+|   # | Flag   | LType   | LSize     | LValue   | Op   | RType   | RSize   | RValue   | Hits   |
+|----:|:-------|:--------|:----------|:---------|:-----|:--------|:--------|:---------|:-------|
+|   1 |        | Mem     | 24-bit BE | 0x1000   | =    | Value   |         | 0x48656c |        |
 
 ### Example 4: Transform method
 `string_equals(0x1000, "Hello World", transform=delta)`

--- a/pycheevos/utils/markdown.py
+++ b/pycheevos/utils/markdown.py
@@ -1,0 +1,119 @@
+from pycheevos.core.condition import Condition
+from pycheevos.core.constants import MemoryType, MemorySize
+from pycheevos.core.helpers import Flag
+from pycheevos.core.value import MemoryValue, RecallValue, ConstantValue
+from tabulate import tabulate
+
+FLAG_MAPPING = {
+    Flag.NONE: "",
+    Flag.PAUSE_IF: "PauseIf",
+    Flag.RESET_IF: "ResetIf",
+    Flag.RESET_NEXT_IF: "ResetNextIf",
+    Flag.ADD_HITS: "AddHits",
+    Flag.SUB_HITS: "SubHits",
+    Flag.ADD_SOURCE: "AddSource",
+    Flag.SUB_SOURCE: "SubSource",
+    Flag.ADD_ADDRESS: "AddAddress",
+    Flag.MEASURED: "Measured",
+    Flag.TRIGGER: "Trigger",
+    Flag.AND_NEXT: "AndNext",
+    Flag.OR_NEXT: "OrNext",
+    Flag.MEASURED_PERCENT: "Measured%",
+    Flag.MEASURED_IF: "MeasuredIf",
+    Flag.REMEMBER: "Remember",
+}
+
+SIZE_MAPPING = {
+    MemorySize.BIT0: "Bit0",
+    MemorySize.BIT1: "Bit1",
+    MemorySize.BIT2: "Bit2",
+    MemorySize.BIT3: "Bit3",
+    MemorySize.BIT4: "Bit4",
+    MemorySize.BIT5: "Bit5",
+    MemorySize.BIT6: "Bit6",
+    MemorySize.BIT7: "Bit7",
+    MemorySize.BIT8: "8-bit",
+    MemorySize.BIT16: "16-bit",
+    MemorySize.BIT24: "24-bit",
+    MemorySize.BIT32: "32-bit",
+    MemorySize.BIT16_BE: "16-bit BE",
+    MemorySize.BIT24_BE: "24-bit BE",
+    MemorySize.BIT32_BE: "32-bit BE",
+    MemorySize.LOWER4: "Lower4",
+    MemorySize.UPPER4: "Upper4",
+    MemorySize.BITCOUNT: "Bitcount",
+    MemorySize.FLOAT: "Float",
+    MemorySize.FLOAT_BE: "Float BE",
+    MemorySize.DOUBLE32: "Double32",
+    MemorySize.DOUBLE32_BE: "Double32 BE",
+    MemorySize.MBF32: "MBF32",
+    MemorySize.MBF32_LE: "MBF32 LE",
+}
+
+TYPE_MAPPING = {
+    MemoryType.MEM: "Mem",
+    MemoryType.DELTA: "Delta",
+    MemoryType.PRIOR: "Prior",
+    MemoryType.INVERT: "Invert",
+    MemoryType.BCD: "BCD",
+    MemoryType.RECALL: "Recall",
+}
+
+def format_type(value: MemoryValue | ConstantValue | RecallValue | None):
+    if isinstance(value, ConstantValue):
+        return "Value"
+    elif isinstance(value, RecallValue):
+        return "Recall"
+    elif isinstance(value, MemoryValue):
+        return TYPE_MAPPING[value.mtype]
+    else:
+        ""
+
+def format_size(value: MemoryValue | ConstantValue | RecallValue | None):
+    if isinstance(value, MemoryValue):
+        return SIZE_MAPPING[value.size]
+    else:
+        return ""
+    
+def format_value(value: MemoryValue | ConstantValue | RecallValue | None):
+    if isinstance(value, ConstantValue):
+        if isinstance(value.value, float):
+            return f"{value.value:.3f}f"
+        return hex(value.value)
+    elif isinstance(value, RecallValue):
+        return "{recall}"
+    elif isinstance(value, MemoryValue):
+        return hex(value.address)
+    else:
+        ""
+
+def format_hits(hits: int):
+    if hits == 0:
+        return ""
+    return f"({hits})"
+
+def format_markdown(logic: list[Condition]):
+    data = [
+        {
+            "#": i + 1,
+            "Flag": FLAG_MAPPING[cond.flag],
+            "LType": format_type(cond.lvalue),
+            "LSize": format_size(cond.lvalue),
+            "LValue": format_value(cond.lvalue),
+            "Op": cond.cmp,
+            "RType": format_type(cond.rvalue),
+            "RSize": format_size(cond.rvalue),
+            "RValue": format_value(cond.rvalue),
+            "Hits": format_hits(cond.hits)
+        }
+        for i, cond in enumerate(logic)
+    ]
+    return tabulate(
+        data,
+        tablefmt="pipe",
+        headers="keys",
+    )
+
+def display_markdown(logic: list[Condition]):
+    print(format_markdown(logic))
+    print()


### PR DESCRIPTION
Hello,

I have made some quality of life changes that I would like to merge into the main branch to improve pycheevos
- Add render method to ConditionList to allow for f-string formatting in rich presence for complex conditions
- Fix some typing errors in `value.py` introduced by the last commit  618e54e8c2117123e585f428afa0176c9a211534
- New helper methods inspired from RATools, with examples
  - `string_equals`: string comparison method, useful for string-based keys used in more modern consoles
  - `always_true`, `always_false`: self explanatory
  - `group`: shortcut for `ConditionList([conditions...])`
- Logic markdown generator script, this is what I used to generate the tables in `strings.md` which is convenient to generate output examples in documentation.

Feel free to review, improve or cherry pick any commit that you want to pull